### PR TITLE
Add .env.example to gitignore and improve admin dashboard styling

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -5,12 +5,6 @@
 @source '../**/*.blade.php';
 @source '../**/*.js';
 
-html {
-  margin: 0;
-  padding: 0;
-  box-sizing: border-box;
-}
-
 @theme {
     --font-sans: 'Instrument Sans', ui-sans-serif, system-ui, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji',
         'Segoe UI Symbol', 'Noto Color Emoji';

--- a/resources/views/AdminDashboard.blade.php
+++ b/resources/views/AdminDashboard.blade.php
@@ -46,7 +46,7 @@
 @endphp
 
 <section class="mx-auto flex min-h-screen w-full overflow-hidden bg-[#EAEAEA]">
-  <div class="flex w-[330px] shrink-0 flex-col rounded-r-[26px] bg-[#223E96] px-12 py-8 text-white shadow-sm">
+  <div class="flex w-82.5 shrink-0 flex-col rounded-r-[26px] bg-[#223E96] px-12 py-8 text-white shadow-sm">
     <div class="mb-14">
       <div class="mb-3 flex items-center gap-3">
         <h1 class="">Filkom Event</h1>
@@ -116,7 +116,7 @@
     </section>
 
     <div class="grid grid-cols-[308px_1fr] gap-12 pb-6">
-      <div class="rounded-[24px] bg-[#0790C7] px-7 py-7 text-white shadow-sm">
+      <div class="rounded-3xl bg-[#0790C7] px-7 py-7 text-white shadow-sm">
         <h2 class="mb-6 text-[28px] font-extrabold leading-tight">
           New Activities
         </h2>
@@ -134,10 +134,10 @@
         </div>
       </div>
 
-      <div class="rounded-[24px] bg-[#16B6D9] px-9 py-9 shadow-sm">
+      <div class="rounded-3xl bg-[#16B6D9] px-9 py-9 shadow-sm">
         <div class="mb-9 grid grid-cols-3 gap-9">
           @foreach ($stats as $item)
-            <div class="flex h-[170px] items-center justify-center rounded-[24px] bg-[#FF6A27] px-6 text-center text-white">
+            <div class="flex h-42.5 items-center justify-center rounded-3xl bg-[#FF6A27] px-6 text-center text-white">
               <div>
                 <div class="mb-4 text-[54px] font-extrabold leading-none">{{ $item['value'] }}</div>
                 <div class="text-[17px] leading-snug">{{ $item['label'] }}</div>

--- a/resources/views/AdminDashboard.blade.php
+++ b/resources/views/AdminDashboard.blade.php
@@ -1,0 +1,166 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport"
+        content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
+  <meta http-equiv="X-UA-Compatible" content="ie=edge">
+  @vite(['resources/css/app.css', 'resources/js/app.js'])
+  <title>Admin - Dashboard</title>
+</head>
+<body>
+@php
+  $menuItems = [
+      ['icon' => 'assets/icons/home.svg', 'label' => 'Dashboard', 'active' => true],
+      ['icon' => 'assets/icons/bookmark.svg', 'label' => 'Events', 'active' => false],
+      ['icon' => 'assets/icons/history.svg', 'label' => 'User Management', 'active' => false],
+  ];
+
+  $settingItems = [
+      ['icon' => 'assets/icons/profile.svg', 'label' => 'Profile'],
+      ['icon' => 'assets/icons/logout.svg', 'label' => 'Logout'],
+  ];
+
+  $adminCard = [
+    ['title' => "Event Management", 'desc' => "Manage all existing events by editing information and monitoring event status.", 'action' => "Enter Event Management"],
+    ['title' => "Add Event", 'desc' => "Create new events easily and quickly.", 'action' => "Add New Event"],
+    ['title' => "Account Management", 'desc' => "Manage user access rights.", 'action' => "Manage Users"],
+  ];
+
+  $actCard = [
+    ['title' => "John Doe mendaftar untuk event Workshop React.js", 'desc' => "2 minutes ago"],
+    ['title' => "The Digital Marketing Seminar Event has been updated", 'desc' => "30 minutes ago"],
+    ['title' => "UI/UX Workshop Certificate for the event has been uploaded", 'desc' => "1 hour ago"],
+  ];
+
+  $stats = [
+      ['value' => '24', 'label' => 'Total Event'],
+      ['value' => '08', 'label' => 'Event Takes Place'],
+      ['value' => '15', 'label' => 'New Registrant'],
+  ];
+
+  $reqAction = [
+    ['title' => "Workshop UI/UX Design", 'desc' => "Completed 2 days ago - Upload Certificate"],
+    ['title' => "Web Development Training", 'desc' => "Finished today - Upload Certificate"],
+  ]
+@endphp
+
+<section class="mx-auto flex min-h-screen w-full overflow-hidden bg-[#EAEAEA]">
+  <div class="flex w-[330px] shrink-0 flex-col rounded-r-[26px] bg-[#223E96] px-12 py-8 text-white shadow-sm">
+    <div class="mb-14">
+      <div class="mb-3 flex items-center gap-3">
+        <h1 class="">Filkom Event</h1>
+          <div class="hidden leading-none">
+        <div class="text-[30px] font-extrabold tracking-wide">FILKOM</div>
+        <div class="text-[30px] font-extrabold tracking-wide">EVENT</div>
+      </div>
+    </div>
+  </div>
+
+  <div>
+    <h2 class="mb-8 text-[26px] font-extrabold tracking-wide">MAIN MENU</h2>
+    <nav class="space-y-8">
+      @foreach ($menuItems as $item)
+        <div class="flex items-center gap-8 text-[24px] {{ $item['active'] ? 'font-bold text-white' : 'text-white/90' }}">
+
+          <span>{{ $item['label'] }}</span>
+        </div>
+      @endforeach
+    </nav>
+  </div>
+
+  <div class="mt-auto pt-16">
+    <h2 class="mb-8 text-[26px] font-extrabold tracking-wide">SETTING</h2>
+    <div class="space-y-8">
+      @foreach ($settingItems as $item)
+        <div class="flex items-center gap-8 text-[24px] text-white/90">
+          <span>{{ $item['label'] }}</span>
+        </div>
+      @endforeach
+    </div>
+  </div>
+  </div>
+
+  <div class="flex-1 overflow-y-auto px-12 py-8">
+    <div class="mb-8 flex items-start justify-between gap-6">
+      <div class="relative w-full max-w-[660px]">
+        <input
+          type="text"
+          placeholder="Search here"
+          class="h-14 w-full rounded-xl border-0 bg-[#03479B] pl-16 pr-5 text-lg text-white placeholder:text-white/80 focus:outline-none"
+        >
+      </div>
+
+      <button class="flex h-[58px] w-[58px] items-center justify-center rounded-full bg-[#233E98] shadow-sm">
+      </button>
+    </div>
+
+    <div class="mb-8 flex items-center gap-5">
+      <div class="flex h-19.5 w-19.5 items-center justify-center overflow-hidden rounded-2xl bg-white shadow-sm">
+
+      </div>
+      <h1 class="text-[60px] font-extrabold leading-none tracking-tight text-black">
+        Welcome, <span class="text-[#FF742E]">Admin!</span>
+      </h1>
+    </div>
+
+    <section class="mb-12 grid grid-cols-3 gap-12">
+      @foreach($adminCard as $item)
+        <div class="w-full bg-secondary-dark rounded-[20px] flex flex-col gap-4 p-4 text-white">
+          <div class="h-15 w-15 rounded-2xl bg-white"></div>
+          <h1 class="text-2xl">{{$item['title']}}</h1>
+          <p class="text-sm">{{$item['desc']}}</p>
+          <button class="bg-orange rounded-full py-2 mt-auto cursor-pointer hover:scale-105 duration-300" type="submit">{{$item['action']}}</button>
+        </div>
+      @endforeach
+    </section>
+
+    <div class="grid grid-cols-[308px_1fr] gap-12 pb-6">
+      <div class="rounded-[24px] bg-[#0790C7] px-7 py-7 text-white shadow-sm">
+        <h2 class="mb-6 text-[28px] font-extrabold leading-tight">
+          New Activities
+        </h2>
+
+        <div class="space-y-7">
+          @foreach ($actCard as $item)
+            <div class="flex justify-between rounded-[20px] bg-[#ECECEC] gap-4 px-6 py-5">
+              <div class="bg-primary-dark  w-10 h-5 rounded-full"></div>
+              <div>
+                <h2 class="text-[14px] font-bold text-[#FF6A27]">{{ $item['title'] }}</h2>
+                <p class="text-[11px] text-[#314A9A]">{{ $item['desc'] }}</p>
+              </div>
+            </div>
+          @endforeach
+        </div>
+      </div>
+
+      <div class="rounded-[24px] bg-[#16B6D9] px-9 py-9 shadow-sm">
+        <div class="mb-9 grid grid-cols-3 gap-9">
+          @foreach ($stats as $item)
+            <div class="flex h-[170px] items-center justify-center rounded-[24px] bg-[#FF6A27] px-6 text-center text-white">
+              <div>
+                <div class="mb-4 text-[54px] font-extrabold leading-none">{{ $item['value'] }}</div>
+                <div class="text-[17px] leading-snug">{{ $item['label'] }}</div>
+              </div>
+            </div>
+          @endforeach
+        </div>
+
+        <div class="flex flex-col gap-8 h-auto p-8 overflow-hidden rounded-[28px] bg-[#FF6A27]">
+          <h1 class="text-3xl text-white font-bold">Event Require Action</h1>
+          @foreach($reqAction as $item)
+            <div class="flex gap-4 bg-white p-4 w-full rounded-3xl">
+              <div class="w-15 h-15 rounded-2xl bg-primary-dark"></div>
+              <div class="flex flex-col">
+                <h4 class="text-[20px]">{{$item['title']}}</h4>
+                <p>{{$item['desc']}}</p>
+              </div>
+            </div>
+          @endforeach
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+</body>
+</html>

--- a/resources/views/bookmark.blade.php
+++ b/resources/views/bookmark.blade.php
@@ -1,0 +1,217 @@
+{{-- resources/views/bookmark.blade.php --}}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Filkom Event - Bookmark</title>
+    @vite(['resources/css/app.css', 'resources/js/app.js'])
+</head>
+<body class="min-h-screen bg-[#EAEAEA] text-slate-900">
+    @php
+        $menuItems = [
+            ['icon' => 'assets/icons/home.svg', 'label' => 'Dashboard', 'href' => '/dashboard-design', 'active' => false],
+            ['icon' => 'assets/icons/bookmark.svg', 'label' => 'Bookmark', 'href' => '/bookmark-design', 'active' => true],
+            ['icon' => 'assets/icons/history.svg', 'label' => 'History', 'href' => '#', 'active' => false],
+            ['icon' => 'assets/icons/list-event.svg', 'label' => 'List Event', 'href' => '#', 'active' => false],
+        ];
+
+        $settingItems = [
+            ['icon' => 'assets/icons/profile.svg', 'label' => 'Profile', 'href' => '#'],
+            ['icon' => 'assets/icons/logout.svg', 'label' => 'Logout', 'href' => '#'],
+        ];
+
+        $bookmarks = [
+        [
+            'title' => 'App Design',
+            'description' => 'Learn App Design from our expert trainer',
+            'participants' => '50 participant',
+            'time' => '13:00 - 17:00 WIB',
+            'image' => 'assets/events/event-1.png',
+        ],
+        [
+            'title' => 'App Design',
+            'description' => 'Learn App Design from our expert trainer',
+            'participants' => '50 participant',
+            'time' => '13:00 - 17:00 WIB',
+            'image' => 'assets/events/event-2.png',
+        ],
+        [
+            'title' => 'App Design',
+            'description' => 'Learn App Design from our expert trainer',
+            'participants' => '50 participant',
+            'time' => '13:00 - 17:00 WIB',
+            'image' => 'assets/events/event-3.png',
+        ],
+        [
+            'title' => 'App Design',
+            'description' => 'Learn App Design from our expert trainer',
+            'participants' => '50 participant',
+            'time' => '13:00 - 17:00 WIB',
+            'image' => 'assets/events/event-4.png',
+        ],
+        [
+            'title' => 'App Design',
+            'description' => 'Learn App Design from our expert trainer',
+            'participants' => '50 participant',
+            'time' => '13:00 - 17:00 WIB',
+            'image' => 'assets/events/event-5.png',
+        ],
+        [
+            'title' => 'App Design',
+            'description' => 'Learn App Design from our expert trainer',
+            'participants' => '50 participant',
+            'time' => '13:00 - 17:00 WIB',
+            'image' => 'assets/events/event-6.png',
+        ],
+    ];
+    @endphp
+
+    <div class="mx-auto flex min-h-screen w-full max-w-[1440px] overflow-hidden bg-[#EAEAEA]">
+        <aside class="flex w-[330px] shrink-0 flex-col rounded-r-[26px] bg-[#223E96] px-12 py-8 text-white shadow-sm">
+            <div class="mb-14">
+                <div class="mb-3">
+                    <img
+                        src="{{ asset('assets/logo/logo-filkom.png') }}"
+                        alt="Logo Filkom Event"
+                        class="w-[150px] object-contain"
+                        onerror="this.style.display='none'; this.nextElementSibling.style.display='block';"
+                    >
+                    <div class="hidden leading-none">
+                        <div class="text-[30px] font-extrabold tracking-wide">FILKOM</div>
+                        <div class="text-[30px] font-extrabold tracking-wide">EVENT</div>
+                    </div>
+                </div>
+            </div>
+
+            <div>
+                <h2 class="mb-8 text-[26px] font-extrabold tracking-wide">MAIN MENU</h2>
+                <nav class="space-y-8">
+                    @foreach ($menuItems as $item)
+                        <a href="{{ $item['href'] }}" class="flex items-center gap-8 text-[24px] {{ $item['active'] ? 'font-bold text-white' : 'text-white/90' }}">
+                            <div class="flex h-10 w-10 items-center justify-center">
+                                <img src="{{ asset($item['icon']) }}" alt="{{ $item['label'] }}" class="h-8 w-8 object-contain">
+                            </div>
+                            <span>{{ $item['label'] }}</span>
+                        </a>
+                    @endforeach
+                </nav>
+            </div>
+
+            <div class="mt-auto pt-16">
+                <h2 class="mb-8 text-[26px] font-extrabold tracking-wide">SETTING</h2>
+                <div class="space-y-8">
+                    @foreach ($settingItems as $item)
+                        <a href="{{ $item['href'] }}" class="flex items-center gap-8 text-[24px] text-white/90">
+                            <div class="flex h-10 w-10 items-center justify-center">
+                                <img src="{{ asset($item['icon']) }}" alt="{{ $item['label'] }}" class="h-8 w-8 object-contain">
+                            </div>
+                            <span>{{ $item['label'] }}</span>
+                        </a>
+                    @endforeach
+                </div>
+            </div>
+        </aside>
+
+        <main class="flex-1 overflow-y-auto px-[42px] py-8">
+            <div class="mb-8 flex items-start justify-between gap-6">
+                <div class="relative w-full max-w-[520px]">
+                    <img
+                        src="{{ asset('assets/icons/search.svg') }}"
+                        alt="Search"
+                        class="pointer-events-none absolute left-4 top-1/2 h-6 w-6 -translate-y-1/2 object-contain"
+                    >
+                    <input
+                        type="text"
+                        placeholder="Search here"
+                        class="h-[55px] w-full rounded-[12px] border-0 bg-[#03479B] pl-14 pr-5 text-[16px] text-white placeholder:text-white/85 focus:outline-none"
+                    >
+                </div>
+
+                <button class="flex h-[58px] w-[58px] items-center justify-center rounded-full bg-[#233E98] shadow-sm">
+                    <img src="{{ asset('assets/icons/profile-top.svg') }}" alt="Profile" class="h-7 w-7 object-contain">
+                </button>
+            </div>
+
+            <div class="mb-6 flex items-center gap-5">
+                <div class="flex h-[92px] w-[92px] items-center justify-center overflow-hidden rounded-2xl bg-transparent">
+                    <img
+                        src="{{ asset('assets/mascot/mascot-student.png') }}"
+                        alt="Mascot"
+                        class="h-full w-full object-contain"
+                        onerror="this.style.display='none'; this.parentElement.innerHTML='🦊'; this.parentElement.classList.add('text-[54px]');"
+                    >
+                </div>
+                <h1 class="text-[54px] font-extrabold leading-none tracking-tight text-black">
+                    My <span class="text-[#FF742E]">Bookmarks</span>
+                </h1>
+            </div>
+
+            <section class="pb-6">
+                <div class="mx-auto grid max-w-[1040px] grid-cols-2 gap-x-[56px] gap-y-[56px]">
+                    @foreach ($bookmarks as $card)
+                        <article class="w-full rounded-[24px] bg-[#14B3D8] px-7 py-4 shadow-sm">
+                            <div class="flex items-center gap-7">
+                                <div class="h-[170px] w-[111px] shrink-0 overflow-hidden rounded-[22px] bg-[#ECECEC]">
+                                    <img
+                                        src="{{ asset($card['image']) }}"
+                                        alt="{{ $card['title'] }}"
+                                        class="h-full w-full object-cover"
+                                        onerror="this.style.display='none';"
+                                    >
+                                </div>
+
+                                <div class="min-w-0 flex-1 pt-2">
+                                    <h2 class="mb-3 text-[16px] font-bold text-[#032A83]">{{ $card['title'] }}</h2>
+
+                                    <p class="mb-4 max-w-[170px] text-[10px] leading-[1.35] text-[#EAF8FF]">
+                                        {{ $card['description'] }}
+                                    </p>
+
+                                    <div class="mb-4 space-y-3 text-[10px] text-[#EAF8FF]">
+                                        <div class="flex items-center gap-3">
+                                            <img src="{{ asset('assets/icons/participants-dark.svg') }}" alt="Participants" class="h-4 w-4 object-contain">
+                                            <span>{{ $card['participants'] }}</span>
+                                        </div>
+
+                                        <div class="flex items-center gap-3">
+                                            <img src="{{ asset('assets/icons/clock-dark.svg') }}" alt="Time" class="h-4 w-4 object-contain">
+                                            <span>{{ $card['time'] }}</span>
+                                        </div>
+                                    </div>
+
+                                    <div class="flex items-center gap-4">
+                                        <button class="h-[36px] flex-1 rounded-[12px] bg-[#FF6A27] px-5 text-[14px] font-semibold text-white">
+                                            See Details
+                                        </button>
+
+                                        <button class="flex h-[36px] w-[36px] items-center justify-center rounded-[10px] bg-white shadow-sm">
+                                            <img src="{{ asset('assets/icons/bookmark-blue.svg') }}" alt="Bookmark" class="h-5 w-5 object-contain">
+                                        </button>
+                                    </div>
+                                </div>
+                            </div>
+                        </article>
+                    @endforeach
+                </div>
+
+                <div class="mt-8 flex items-center justify-center gap-4">
+                    <button class="flex h-[34px] w-[34px] items-center justify-center rounded-[6px] border border-[#C9C9C9] bg-[#EAEAEA]">
+                        <img src="{{ asset('assets/icons/arrow-left.svg') }}" alt="Previous" class="h-4 w-4 object-contain">
+                    </button>
+
+                    <button class="flex h-[40px] w-[33px] items-center justify-center rounded-[6px] bg-[#233E98] font-semibold text-white">
+                        1
+                    </button>
+                    <button class="text-[#444444]">2</button>
+                    <button class="text-[#444444]">3</button>
+
+                    <button class="flex h-[34px] w-[34px] items-center justify-center rounded-[6px] border border-[#C9C9C9] bg-[#EAEAEA]">
+                        <img src="{{ asset('assets/icons/arrow-right.svg') }}" alt="Next" class="h-4 w-4 object-contain">
+                    </button>
+                </div>
+            </section>
+        </main>
+    </div>
+</body>
+</html>

--- a/resources/views/history.blade.php
+++ b/resources/views/history.blade.php
@@ -1,0 +1,237 @@
+{{-- resources/views/history.blade.php --}}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Filkom Event - History</title>
+    @vite(['resources/css/app.css', 'resources/js/app.js'])
+</head>
+<body class="min-h-screen bg-[#EAEAEA] text-slate-900">
+    @php
+        $menuItems = [
+            ['icon' => 'assets/icons/home.svg', 'label' => 'Dashboard', 'href' => '/dashboard-design', 'active' => false],
+            ['icon' => 'assets/icons/bookmark.svg', 'label' => 'Bookmark', 'href' => '/bookmark-design', 'active' => false],
+            ['icon' => 'assets/icons/history.svg', 'label' => 'History', 'href' => '/history-design', 'active' => true],
+            ['icon' => 'assets/icons/list-event.svg', 'label' => 'List Event', 'href' => '#', 'active' => false],
+        ];
+
+        $settingItems = [
+            ['icon' => 'assets/icons/profile.svg', 'label' => 'Profile', 'href' => '#'],
+            ['icon' => 'assets/icons/logout.svg', 'label' => 'Logout', 'href' => '#'],
+        ];
+
+        $historyItems = [
+            [
+                'title' => 'App Design',
+                'date' => '15 January 2025 - 16 January 2025',
+                'description' => 'Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
+                'event_status' => 'Completed',
+                'payment_status' => 'Paid off',
+                'action' => 'Download Certificate',
+                'action_type' => 'download',
+            ],
+            [
+                'title' => 'App Design',
+                'date' => '15 January 2025 - 16 January 2025',
+                'description' => 'Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
+                'event_status' => 'Occur',
+                'payment_status' => 'Waiting for Payment',
+                'action' => 'See Details',
+                'action_type' => 'details',
+            ],
+            [
+                'title' => 'App Design',
+                'date' => '15 January 2025 - 16 January 2025',
+                'description' => 'Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
+                'event_status' => 'Completed',
+                'payment_status' => 'Canceled',
+                'action' => 'Not Available',
+                'action_type' => 'disabled',
+            ],
+        ];
+    @endphp
+
+    <div class="mx-auto flex min-h-screen w-full max-w-[1440px] overflow-hidden bg-[#EAEAEA]">
+        <aside class="flex w-[330px] shrink-0 flex-col rounded-r-[26px] bg-[#223E96] px-12 py-8 text-white shadow-sm">
+            <div class="mb-14">
+                <div class="mb-3">
+                    <img
+                        src="{{ asset('assets/logo/logo-filkom.png') }}"
+                        alt="Logo Filkom Event"
+                        class="w-[150px] object-contain"
+                        onerror="this.style.display='none'; this.nextElementSibling.style.display='block';"
+                    >
+                    <div class="hidden leading-none">
+                        <div class="text-[30px] font-extrabold tracking-wide">FILKOM</div>
+                        <div class="text-[30px] font-extrabold tracking-wide">EVENT</div>
+                    </div>
+                </div>
+            </div>
+
+            <div>
+                <h2 class="mb-8 text-[26px] font-extrabold tracking-wide">MAIN MENU</h2>
+                <nav class="space-y-8">
+                    @foreach ($menuItems as $item)
+                        <a href="{{ $item['href'] }}" class="flex items-center gap-8 text-[24px] {{ $item['active'] ? 'font-bold text-white' : 'text-white/90' }}">
+                            <div class="flex h-10 w-10 items-center justify-center">
+                                <img src="{{ asset($item['icon']) }}" alt="{{ $item['label'] }}" class="h-8 w-8 object-contain">
+                            </div>
+                            <span>{{ $item['label'] }}</span>
+                        </a>
+                    @endforeach
+                </nav>
+            </div>
+
+            <div class="mt-auto pt-16">
+                <h2 class="mb-8 text-[26px] font-extrabold tracking-wide">SETTING</h2>
+                <div class="space-y-8">
+                    @foreach ($settingItems as $item)
+                        <a href="{{ $item['href'] }}" class="flex items-center gap-8 text-[24px] text-white/90">
+                            <div class="flex h-10 w-10 items-center justify-center">
+                                <img src="{{ asset($item['icon']) }}" alt="{{ $item['label'] }}" class="h-8 w-8 object-contain">
+                            </div>
+                            <span>{{ $item['label'] }}</span>
+                        </a>
+                    @endforeach
+                </div>
+            </div>
+        </aside>
+
+        <main class="flex-1 overflow-y-auto px-[44px] py-8">
+            <div class="mb-8 flex items-start justify-between gap-6">
+                <div class="relative w-full max-w-[520px]">
+                    <img
+                        src="{{ asset('assets/icons/search.svg') }}"
+                        alt="Search"
+                        class="pointer-events-none absolute left-4 top-1/2 h-6 w-6 -translate-y-1/2 object-contain"
+                    >
+                    <input
+                        type="text"
+                        placeholder="Search here"
+                        class="h-[55px] w-full rounded-[12px] border-0 bg-[#03479B] pl-14 pr-5 text-[16px] text-white placeholder:text-white/85 focus:outline-none"
+                    >
+                </div>
+
+                <button class="flex h-[58px] w-[58px] items-center justify-center rounded-full bg-[#233E98] shadow-sm">
+                    <img src="{{ asset('assets/icons/profile-top.svg') }}" alt="Profile" class="h-7 w-7 object-contain">
+                </button>
+            </div>
+
+            <div class="mb-6 flex items-center gap-5">
+                <div class="flex h-[92px] w-[92px] items-center justify-center overflow-hidden rounded-2xl bg-transparent">
+                    <img
+                        src="{{ asset('assets/mascot/mascot-student.png') }}"
+                        alt="Mascot"
+                        class="h-full w-full object-contain"
+                        onerror="this.style.display='none'; this.parentElement.innerHTML='🦊'; this.parentElement.classList.add('text-[54px]');"
+                    >
+                </div>
+                <h1 class="text-[54px] font-extrabold leading-none tracking-tight text-black">
+                    My <span class="text-[#FF742E]">Histories</span>
+                </h1>
+            </div>
+
+            <section class="mb-8 rounded-[24px] bg-[#16B6D9] px-[42px] py-[30px] text-white shadow-sm">
+                <h2 class="mb-6 text-[28px] font-extrabold">Filters &amp; Search</h2>
+
+                <div class="grid grid-cols-[220px_220px_1fr] gap-x-[52px]">
+                    <div>
+                        <label class="mb-2 block text-[16px] font-medium text-white/95">Status Event</label>
+                        <div class="relative">
+                            <select class="h-[44px] w-full appearance-none rounded-[8px] border-0 bg-[#F4F4F4] px-4 pr-10 text-[14px] text-[#FF6A27] focus:outline-none">
+                                <option>Semua Status</option>
+                            </select>
+                            <img src="{{ asset('assets/icons/chevron-down-orange.svg') }}" alt="Open" class="pointer-events-none absolute right-4 top-1/2 h-4 w-4 -translate-y-1/2 object-contain">
+                        </div>
+                    </div>
+
+                    <div>
+                        <label class="mb-2 block text-[16px] font-medium text-white/95">Status Pendaftaran</label>
+                        <div class="relative">
+                            <select class="h-[44px] w-full appearance-none rounded-[8px] border-0 bg-[#F4F4F4] px-4 pr-10 text-[14px] text-[#FF6A27] focus:outline-none">
+                                <option>Semua Status</option>
+                            </select>
+                            <img src="{{ asset('assets/icons/chevron-down-orange.svg') }}" alt="Open" class="pointer-events-none absolute right-4 top-1/2 h-4 w-4 -translate-y-1/2 object-contain">
+                        </div>
+                    </div>
+
+                    <div>
+                        <label class="mb-2 block text-[16px] font-medium text-white/95">Pencarian Event</label>
+                        <div class="relative">
+                            <img src="{{ asset('assets/icons/search-orange.svg') }}" alt="Search" class="pointer-events-none absolute left-4 top-1/2 h-5 w-5 -translate-y-1/2 object-contain">
+                            <input
+                                type="text"
+                                placeholder="Search by event name"
+                                class="h-[44px] w-full rounded-[8px] border-0 bg-[#F4F4F4] pl-10 pr-4 text-[14px] text-[#F0A384] placeholder:text-[#F0A384] focus:outline-none"
+                            >
+                        </div>
+                    </div>
+                </div>
+            </section>
+
+            <section class="pb-6">
+                <div class="space-y-6">
+                    @foreach ($historyItems as $item)
+                        <article class="rounded-[24px] bg-[#0A7EBF] px-12 py-8 text-white shadow-sm">
+                            <div class="flex items-start justify-between gap-6">
+                                <div class="max-w-[640px]">
+                                    <div class="mb-2 flex flex-wrap items-center gap-3">
+                                        <h3 class="text-[20px] font-bold">{{ $item['title'] }}</h3>
+
+                                        <span class="inline-flex rounded-full bg-[#050A8F] px-4 py-[5px] text-[12px] font-medium text-white">
+                                            {{ $item['event_status'] }}
+                                        </span>
+
+                                        <span class="inline-flex rounded-full bg-[#FF6A27] px-4 py-[5px] text-[12px] font-medium text-white">
+                                            {{ $item['payment_status'] }}
+                                        </span>
+                                    </div>
+
+                                    <div class="mb-4 text-[14px] text-white/95">{{ $item['date'] }}</div>
+
+                                    <p class="max-w-[620px] text-[14px] leading-[1.35] text-white/95">
+                                        {{ $item['description'] }}
+                                    </p>
+                                </div>
+
+                                <div class="pt-2">
+                                    @if ($item['action_type'] === 'download')
+                                        <button class="inline-flex h-[40px] min-w-[196px] items-center justify-center gap-3 rounded-[8px] bg-[#050A8F] px-5 text-[14px] font-semibold text-white">
+                                            <img src="{{ asset('assets/icons/download-white.svg') }}" alt="Download" class="h-4 w-4 object-contain">
+                                            <span>{{ $item['action'] }}</span>
+                                        </button>
+                                    @elseif ($item['action_type'] === 'details')
+                                        <button class="inline-flex h-[40px] min-w-[196px] items-center justify-center gap-3 rounded-[8px] bg-[#050A8F] px-5 text-[14px] font-semibold text-white">
+                                            <img src="{{ asset('assets/icons/eye-white.svg') }}" alt="Details" class="h-4 w-4 object-contain">
+                                            <span>{{ $item['action'] }}</span>
+                                        </button>
+                                    @else
+                                        <button class="inline-flex h-[40px] min-w-[196px] items-center justify-center rounded-[8px] bg-[#0C4E9B] px-5 text-[14px] font-medium text-white/95">
+                                            {{ $item['action'] }}
+                                        </button>
+                                    @endif
+                                </div>
+                            </div>
+                        </article>
+                    @endforeach
+                </div>
+
+                <div class="mt-8 flex items-center justify-center gap-4">
+                    <button class="flex h-[34px] w-[34px] items-center justify-center rounded-[6px] border border-[#C9C9C9] bg-[#EAEAEA]">
+                        <img src="{{ asset('assets/icons/arrow-left.svg') }}" alt="Previous" class="h-4 w-4 object-contain">
+                    </button>
+
+                    <button class="flex h-[40px] w-[33px] items-center justify-center rounded-[6px] bg-[#233E98] font-semibold text-white">1</button>
+                    <button class="text-[#444444]">2</button>
+                    <button class="text-[#444444]">3</button>
+
+                    <button class="flex h-[34px] w-[34px] items-center justify-center rounded-[6px] border border-[#C9C9C9] bg-[#EAEAEA]">
+                        <img src="{{ asset('assets/icons/arrow-right.svg') }}" alt="Next" class="h-4 w-4 object-contain">
+                    </button>
+                </div>
+            </section>
+        </main>
+    </div>
+</body>
+</html>

--- a/routes/web.php
+++ b/routes/web.php
@@ -9,3 +9,7 @@ Route::get('/dashboard-design', function () {
 Route::get('/bookmark-design', function () {
     return view('bookmark');
 });
+
+Route::get('/history-design', function () {
+    return view('history');
+});

--- a/routes/web.php
+++ b/routes/web.php
@@ -9,3 +9,11 @@ Route::get('/dashboard-design', function () {
 Route::get('/', function () {
     return view('home');
 });
+
+Route::get('/admin/dashboard', function () {
+  return view('AdminDashboard');
+});
+
+Route::get('/history-design', function () {
+  return view('history');
+});

--- a/routes/web.php
+++ b/routes/web.php
@@ -5,3 +5,7 @@ use Illuminate\Support\Facades\Route;
 Route::get('/dashboard-design', function () {
     return view('dashboard');
 });
+
+Route::get('/bookmark-design', function () {
+    return view('bookmark');
+});


### PR DESCRIPTION
This pull request introduces two new Blade view templates for the admin dashboard and bookmark pages, adds a new color theme to the CSS, updates the editor configuration for consistent indentation, and removes the example environment configuration file. The main focus is on UI development and theming.

**New view templates:**

* Added `AdminDashboard.blade.php` with a structured admin dashboard layout, including navigation, statistics, activity cards, and event management sections.
* Added `bookmark.blade.php` to display a user's bookmarked events, featuring a sidebar, search, event cards, and pagination controls.

**Styling and theming:**

* Introduced a new `@theme` section in `app.css` with custom color variables for primary, secondary, tertiary, orange, and blue shades.

**Configuration updates:**

* Changed `indent_size` from 4 to 2 in `.editorconfig` to standardize code formatting.
* Removed `.env.example`, which previously contained example environment variables for the application.