### PR TITLE
Clarify label for obtained certificates in dashboard

### DIFF
--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -12,136 +12,136 @@ use App\Models\User;
 
 class AuthController extends Controller
 {
-    public function register(Request $request)
-    {
-        $request->validate([
-            'nim' => 'required|unique:users,nim',
-            'name' => 'required',
-            'email' => 'required|email|ends_with:@student.ub.ac.id|unique:users,email',
-            'password' => 'required|min:8|confirmed'
-        ], [
-            'nim.required' => 'NIM wajib diisi',
-            'nim.unique' => 'NIM sudah terdaftar',
+  public function register(Request $request)
+  {
+    $request->validate([
+      'nim' => 'required|unique:users,nim',
+      'name' => 'required',
+      'email' => 'required|email|ends_with:@student.ub.ac.id|unique:users,email',
+      'password' => 'required|min:8|confirmed'
+    ], [
+      'nim.required' => 'NIM wajib diisi',
+      'nim.unique' => 'NIM sudah terdaftar',
 
-            'email.required' => 'Email wajib diisi',
-            'email.email' => 'Format email tidak valid',
-            'email.ends_with' => 'Gunakan email UB (@student.ub.ac.id)',
-            'email.unique' => 'Email sudah digunakan',
+      'email.required' => 'Email wajib diisi',
+      'email.email' => 'Format email tidak valid',
+      'email.ends_with' => 'Gunakan email UB (@student.ub.ac.id)',
+      'email.unique' => 'Email sudah digunakan',
 
-            'password.required' => 'Password wajib diisi',
-            'password.min' => 'Password minimal 8 karakter',
-            'password.confirmed' => 'Konfirmasi password tidak sama',
-        ]);
+      'password.required' => 'Password wajib diisi',
+      'password.min' => 'Password minimal 8 karakter',
+      'password.confirmed' => 'Konfirmasi password tidak sama',
+    ]);
 
-        User::create([
-            'nim' =>  $request->nim,
-            'name' =>  $request->name,
-            'email' =>  $request->email,
-            'password' => $request->password,
-        ]);
+    User::create([
+      'nim' =>  $request->nim,
+      'name' =>  $request->name,
+      'email' =>  $request->email,
+      'password' => $request->password,
+    ]);
 
-        return redirect('login')->with('success', 'Akun Berhasil Dibuat');
-    }
+    return redirect('login')->with('success', 'Akun Berhasil Dibuat');
+  }
 
-    public function login(Request $request)
-    {
-        $request->validate([
-            'email' => 'required|email',
-            'password' => 'required'
-        ], [
-            'email.required' => 'Email wajib diisi',
-            'email.email' => 'Format email tidak valid',
-            'email.ends_with' => 'Gunakan email UB (@student.ub.ac.id)',
-            'email.unique' => 'Email sudah digunakan',
+  public function login(Request $request)
+  {
+    $request->validate([
+      'email' => 'required|email',
+      'password' => 'required'
+    ], [
+      'email.required' => 'Email wajib diisi',
+      'email.email' => 'Format email tidak valid',
+      'email.ends_with' => 'Gunakan email UB (@student.ub.ac.id)',
+      'email.unique' => 'Email sudah digunakan',
 
-            'password.required' => 'Password wajib diisi',
-            'password.min' => 'Password minimal 8 karakter',
-        ]);
+      'password.required' => 'Password wajib diisi',
+      'password.min' => 'Password minimal 8 karakter',
+    ]);
 
-        if (Auth::attempt([
-            'email' => $request->email,
-            'password' => $request->password
-        ])) {
-            $request->session()->regenerate();
+    if (Auth::attempt([
+      'email' => $request->email,
+      'password' => $request->password,
+    ])) {
+      $request->session()->regenerate();
 
-          if (strtolower(Auth::user()->role) === 'admin') {
-            return redirect()->route('admin.dashboard')
-              ->with('success', 'Login berhasil sebagai admin');
-          }
-
-          return redirect()->route('dashboard')
-            ->with('success', 'Login berhasil');
-        }
-
-        return back()
-            ->withErrors(['login' => 'Email atau password salah'])
-            ->onlyInput('email');
-    }
-
-    public function logout(Request $request)
-    {
-        Auth::logout();
-
-        $request->session()->invalidate();
-        $request->session()->regenerateToken();
-
-        return redirect('/login')->with('success', 'Anda berhasil logout');
-    }
-
-    public function sendEmail(Request $request) {
-      $data = $request->validate([
-        'nama' => 'required',
-        'email' => 'required|email',
-        'nim' => 'required',
-        'pesan' => 'required',
-      ]);
-
-      Mail::to('m.fahry.pratama.putra@gmail.com')->send(new ContactMail($data));
-
-      return back()->with('success', "Pesan berhasil dikirim!");
-    }
-
-    public function forgotPassword(Request $request) {
-        $request->validate([
-            'email' => 'required|email|exists:users,email'
-        ]);
-
-        $user = User::where('email', $request->email)->first();
-
-        $token = Str::random(64);
-
-        $user->update([
-            'reset_token' => $token,
-            'reset_token_expired_at' => now()->addMinutes(30)
-        ]);
-
-        $link = url('/reset-password/' . $token);
-
-        Mail::to($user->email)->send(new ResetPassword($link));
-
-        return back()->with('success', 'Link reset dikirim ke email!');
-    }
-
-    public function resetPassword(Request $request) {
-      $request->validate([
-        'token' => 'required',
-        'password' => 'required|min:8|confirmed'
-      ]);
-
-      $user = User::where('reset_token', $request->token)
-        ->where('reset_token_expired_at', '>', now())
-        ->first();
-
-      if (!$user) {
-        return back()->withErrors(['error' => 'Token tidak valid atau expired']);
+      if (strtolower(Auth::user()->role) === 'admin') {
+        return redirect()->route('admin.dashboard')
+          ->with('success', 'Login berhasil sebagai admin');
       }
 
-      $user->update([
-        'password' => bcrypt($request->password),
-        'reset_token' => null,
-        'reset_token_expired_at' => null,
-      ]);
-
-      return redirect('/login')->with('success', 'Password berhasil direset');
+      return redirect()->route('dashboard')
+        ->with('success', 'Login berhasil');
     }
+
+    return back()
+      ->withErrors(['login' => 'Email atau password salah'])
+      ->onlyInput('email');
+  }
+
+  public function logout(Request $request)
+  {
+    Auth::logout();
+
+    $request->session()->invalidate();
+    $request->session()->regenerateToken();
+
+    return redirect('/login')->with('success', 'Anda berhasil logout');
+  }
+
+  public function sendEmail(Request $request) {
+    $data = $request->validate([
+      'nama' => 'required',
+      'email' => 'required|email',
+      'nim' => 'required',
+      'pesan' => 'required',
+    ]);
+
+    Mail::to('m.fahry.pratama.putra@gmail.com')->send(new ContactMail($data));
+
+    return back()->with('success', "Pesan berhasil dikirim!");
+  }
+
+  public function forgotPassword(Request $request) {
+    $request->validate([
+      'email' => 'required|email|exists:users,email'
+    ]);
+
+    $user = User::where('email', $request->email)->first();
+
+    $token = Str::random(64);
+
+    $user->update([
+      'reset_token' => $token,
+      'reset_token_expired_at' => now()->addMinutes(30)
+    ]);
+
+    $link = url('/reset-password/' . $token);
+
+    Mail::to($user->email)->send(new ResetPassword($link));
+
+    return back()->with('success', 'Link reset dikirim ke email!');
+  }
+
+  public function resetPassword(Request $request) {
+    $request->validate([
+      'token' => 'required',
+      'password' => 'required|min:8|confirmed'
+    ]);
+
+    $user = User::where('reset_token', $request->token)
+      ->where('reset_token_expired_at', '>', now())
+      ->first();
+
+    if (!$user) {
+      return back()->withErrors(['error' => 'Token tidak valid atau expired']);
+    }
+
+    $user->update([
+      'password' => bcrypt($request->password),
+      'reset_token' => null,
+      'reset_token_expired_at' => null,
+    ]);
+
+    return redirect('/login')->with('success', 'Password berhasil direset');
+  }
 }

--- a/app/Mail/ResetPassword.php
+++ b/app/Mail/ResetPassword.php
@@ -40,7 +40,7 @@ class ResetPassword extends Mailable
     public function content(): Content
     {
         return new Content(
-            view: 'Email.resetPassword',
+            view: 'Email.reset-password',
         );
     }
 

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -21,6 +21,8 @@ class User extends Authenticatable
       'email',
       'password',
       'role',
+      'reset_token',
+      'reset_token_expired_at',
     ];
 
     protected $hidden = [

--- a/resources/views/Auth/reset-password.blade.php
+++ b/resources/views/Auth/reset-password.blade.php
@@ -6,7 +6,7 @@
         content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
   @vite(['resources/css/auth.css', 'resources/js/app.js'])
-  <title>FilkomEvent - Login</title>
+  <title>FilkomEvent - Reset Password</title>
 </head>
 <body class="relative min-h-screen">
 {{--  For All Icon  --}}
@@ -33,15 +33,22 @@
 
       <div class="flex flex-col justify-center gap-2">
         <label class="text-white text-lg" for="">Password</label>
-        <input name="password" class="bg-white p-2 px-4 rounded-[40px] focus:outline-none focus:ring-0 focus:ring-transparent focus:border-transparent" type="text" placeholder="password">
+        <input name="password" class="bg-white p-2 px-4 rounded-[40px] focus:outline-none focus:ring-0 focus:ring-transparent focus:border-transparent" type="password" placeholder="password">
       </div>
       <div class="flex flex-col justify-center gap-2">
         <label class="text-white text-lg" for="">Konfirmasi Password</label>
-        <input name="password_confirmation" class="bg-white p-2 px-4 rounded-[40px] focus:outline-none focus:ring-0 focus:ring-transparent focus:border-transparent" type="text" placeholder="konfirmasi password">
+        <input name="password_confirmation" class="bg-white p-2 px-4 rounded-[40px] focus:outline-none focus:ring-0 focus:ring-transparent focus:border-transparent" type="password" placeholder="konfirmasi password">
       </div>
       <button class="w-full mt-4 bg-orange-550 p-2 rounded-[40px] cursor-pointer text-white hover:scale-105 transition-transform duration-300 shadow-[0px_4px_0px_rgba(0,0,0,0.3)]">Kirim</button>
     </form>
   </div>
+  @if ($errors->any())
+    <div class="text-red-500">
+      @foreach ($errors->all() as $error)
+        <p>{{ $error }}</p>
+      @endforeach
+    </div>
+  @endif
 </section>
 
 </body>

--- a/routes/web.php
+++ b/routes/web.php
@@ -49,10 +49,7 @@ Route::middleware(['auth', 'role:Mahasiswa'])->group(callback: function() {
 });
 
 // Routing For Admin Page
-Route::middleware(['auth', 'role:admin'])
-  ->prefix('admin')
-  ->name('admin.')
-  ->group(function () {
+Route::middleware(['auth', 'role:admin'])->prefix('admin')->name('admin.')->group(function () {
 
     Route::get('/dashboard', fn() => view('Admin.admin-dashboard'))->name('dashboard');
 


### PR DESCRIPTION
This pull request introduces several improvements and fixes related to password reset functionality and admin routing. The most important changes include updating the password reset email view, enhancing the reset password form for better security and error feedback, and adding new fields to the `User` model for password reset tokens.

**Password Reset Improvements:**

* Changed the password reset email view in `ResetPassword.php` to use the correct Blade template name (`Email.reset-password` instead of `Email.resetPassword`).
* Updated the reset password form in `reset-password.blade.php` to use `type="password"` for password fields and display validation errors to the user.
* Changed the page title in `reset-password.blade.php` to "FilkomEvent - Reset Password" for clarity.

**User Model Enhancements:**

* Added `reset_token` and `reset_token_expired_at` fields to the fillable properties in the `User` model to support password reset functionality.

**Code Style and Routing:**

* Combined the admin route middleware, prefix, and name definitions into a single line for improved readability in `web.php`.

**Minor Fixes:**

* Fixed minor formatting in the `AuthController.php` login method for consistency.