### PR TITLE
Fix view path for events management in AdminEventController

### DIFF
--- a/app/Http/Controllers/AdminEventController.php
+++ b/app/Http/Controllers/AdminEventController.php
@@ -62,7 +62,7 @@ class AdminEventController extends Controller
         }
 
         if ($request->ajax()) {
-            return response()->view('Admin.partials.events-management-results', [
+            return response()->view('partials.events-management-results', [
                 'events' => $events,
             ]);
         }


### PR DESCRIPTION
This pull request makes a minor update to the view path used for rendering AJAX responses in the `index` method of `AdminEventController.php`. The view has been changed from an admin-specific subdirectory to a more general partials directory. 

- Changed the view rendered for AJAX requests in the `index` method from `'Admin.partials.events-management-results'` to `'partials.events-management-results'` in `AdminEventController.php`